### PR TITLE
Refactor auth redirect

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,49 @@
+import * as Auth from "firebase/auth";
+import { auth, provider } from "./firebase";
+import { getScreenName, setScreenName } from "./data/user";
+
+export const signIn = async () => {
+  await Auth.signInWithRedirect(auth, provider);
+};
+
+export const signOut = async () => {
+  await Auth.signOut(auth);
+  window.location.href = "/";
+};
+
+export const setOrGetScreenName = async (user: Auth.User) => {
+  const userId = user.uid;
+  const userCredential = await Auth.getRedirectResult(auth);
+  if (userCredential) {
+    await updateProfile(user);
+
+    const additionalUserInfo = Auth.getAdditionalUserInfo(userCredential);
+    const screenName = additionalUserInfo?.username;
+    if (!screenName) throw new Error("invalid screenName");
+    await setScreenName(userId, screenName);
+    return screenName;
+  } else {
+    const screenName = await getScreenName(userId);
+    return screenName;
+  }
+};
+
+const updateProfile = async (user: Auth.User) => {
+  for (const data of user.providerData) {
+    if (data.providerId === "twitter.com") {
+      const newProfile: {
+        displayName?: string;
+        photoURL?: string;
+      } = {};
+      const photoURL = data.photoURL;
+      if (photoURL && photoURL !== user.photoURL)
+        newProfile.photoURL = photoURL;
+      const displayName = data.displayName;
+      if (displayName && displayName !== user.displayName)
+        newProfile.displayName = displayName;
+
+      if (Object.keys(newProfile).length > 0)
+        Auth.updateProfile(user, newProfile);
+    }
+  }
+};

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -13,10 +13,11 @@ import {
 import { Container } from "@mui/system";
 import { LibraryMusic } from "@mui/icons-material";
 import { Link, Outlet } from "react-router-dom";
-import { User } from "firebase/auth";
 import { UserStateContext } from "../contexts/user";
+import { signIn, signOut } from "../auth";
+import { UserInfo } from "../data/user";
 
-const AvatarMenu: React.FC<{ user: User; signOut: () => void }> = ({
+const AvatarMenu: React.FC<{ user: UserInfo; signOut: () => void }> = ({
   user,
   signOut,
 }) => {
@@ -78,12 +79,12 @@ const AppContainer: React.FC = () => {
             </Link>
             {us.state === "loading" ? (
               <CircularProgress color="inherit" />
-            ) : us.state === "signed out" ? (
-              <Button color="inherit" onClick={us.signIn}>
+            ) : us.state === "signedOut" ? (
+              <Button color="inherit" onClick={signIn}>
                 Log in
               </Button>
             ) : (
-              <AvatarMenu user={us.user} signOut={us.signOut} />
+              <AvatarMenu user={us.user} signOut={signOut} />
             )}
           </Toolbar>
         </Container>

--- a/src/components/EditButton.tsx
+++ b/src/components/EditButton.tsx
@@ -21,7 +21,7 @@ const EditButton: React.FC<{ songEntry: SongEntry }> = ({
 }) => {
   const [formOpen, setFormOpen] = useState(false);
   const us = useContext(UserStateContext);
-  const userId = us.state === "signed in" ? us.user.userId : null;
+  const userId = us.state === "signedIn" ? us.user.userId : null;
   if (userId === null) return <Edit title="編集するときはログインしてね" />;
 
   const onClick = () => {

--- a/src/components/StarButton.tsx
+++ b/src/components/StarButton.tsx
@@ -28,7 +28,7 @@ const StarButton: React.FC<{ songEntry: SongEntry }> = ({
   songEntry: [songId, song],
 }) => {
   const us = useContext(UserStateContext);
-  const userId = us.state === "signed in" ? us.user.userId : null;
+  const userId = us.state === "signedIn" ? us.user.userId : null;
   const [favd, setFavd] = useState(false);
   useEffect(() => {
     if (!userId) return;

--- a/src/contexts/user.ts
+++ b/src/contexts/user.ts
@@ -1,10 +1,10 @@
 import { createContext } from "react";
-import { User } from "../data/user";
+import { UserInfo } from "../data/user";
 
 export type UserState =
   | { state: "loading" }
-  | { state: "signed out"; signIn: () => void }
-  | { state: "signed in"; user: User; signOut: () => void };
+  | { state: "signedOut" }
+  | { state: "signedIn"; user: UserInfo };
 
 export const defaultUserState: UserState = {
   state: "loading",

--- a/src/data/song.ts
+++ b/src/data/song.ts
@@ -102,12 +102,12 @@ export async function watchSongsByScreenName(
   screenName: string,
   onSongsChange: (songEntries: SongEntry[]) => void
 ) {
-  const lowerScreenName = screenName.toLocaleLowerCase();
+  const screenNameLowerCase = screenName.toLocaleLowerCase();
   const path = `${root}/users`;
   const q = query(
     ref(db, path),
-    orderByChild("screenName"),
-    equalTo(lowerScreenName)
+    orderByChild("screenNameLowerCase"),
+    equalTo(screenNameLowerCase)
   );
   const snapshot = await get(q);
   if (!snapshot.exists()) throw new Error("Such screen name does not exist");

--- a/src/data/user.ts
+++ b/src/data/user.ts
@@ -1,29 +1,32 @@
-import { User as AuthUser } from "firebase/auth";
-import { ref, set } from "firebase/database";
+import { get, ref, set } from "firebase/database";
 import { database } from "../firebase";
 import { root } from "./utils";
 
-export type User = AuthUser & {
+export type UserInfo = {
   userId: string;
+  displayName: string;
   screenName: string;
+  photoURL: string;
 };
 
-export function getScreenName(authuser: AuthUser): string {
-  // FIXME: better method to get screen name
-  if (!("reloadUserInfo" in authuser)) return "";
-  const reloadUserInfo = authuser.reloadUserInfo;
-  if (
-    typeof reloadUserInfo !== "object" ||
-    reloadUserInfo === null ||
-    !("screenName" in reloadUserInfo)
-  )
-    return "";
-  const screenName = reloadUserInfo.screenName;
-  if (typeof screenName !== "string") return "";
+export async function getScreenName(userId: string): Promise<string> {
+  const snapshot = await get(
+    ref(database, `${root}/users/${userId}/screenName`)
+  );
+  const screenName = snapshot.val() as unknown;
+  if (typeof screenName !== "string")
+    throw new Error("Stored screenName is not string");
   return screenName;
 }
 
-export function setScreenName(uid: string, screenName: string): Promise<void> {
-  const lowerScreenName = screenName.toLowerCase();
-  return set(ref(database, `${root}/users/${uid}/screenName`), lowerScreenName);
+export async function setScreenName(
+  userId: string,
+  screenName: string
+): Promise<void> {
+  await set(ref(database, `${root}/users/${userId}/screenName`), screenName);
+  const screenNameLowerCase = screenName.toLowerCase();
+  await set(
+    ref(database, `${root}/users/${userId}/screenNameLowerCase`),
+    screenNameLowerCase
+  );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -18,7 +18,7 @@ import SongList from "../components/SongList";
 import SongSubmitForm from "../components/SongSubmitForm";
 import { UserStateContext } from "../contexts/user";
 import UnauthorizedPage from "./UnauthorizedPage";
-import { User } from "../data/user";
+import { UserInfo } from "../data/user";
 import EditButton from "../components/EditButton";
 import FromClipboardForm from "../components/FromClipboardForm";
 
@@ -67,7 +67,7 @@ const FloatingActionButton: React.FC<{
 );
 
 const MyPageContent: React.FC<{
-  user: User;
+  user: UserInfo;
 }> = ({ user }) => {
   const userId = user.userId;
   const [data, setData] = useState<undefined | SongEntry[]>(undefined);
@@ -144,7 +144,7 @@ const MyPageContent: React.FC<{
 const MyPage: React.FC = () => {
   const us = useContext(UserStateContext);
   if (us.state === "loading") return <LoadingPage />;
-  if (us.state === "signed out") return <UnauthorizedPage />;
+  if (us.state === "signedOut") return <UnauthorizedPage />;
 
   return <MyPageContent user={us.user} />;
 };

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -60,7 +60,7 @@ const FloatingActionButton: React.FC<{
   <Fab
     onClick={onClick}
     color="primary"
-    sx={{ position: "absolute", bottom: 32, right: 32 }}
+    sx={{ position: "fixed", bottom: 32, right: 32 }}
   >
     {icon}
   </Fab>

--- a/src/pages/TopPage.tsx
+++ b/src/pages/TopPage.tsx
@@ -4,6 +4,7 @@ import { Container } from "@mui/system";
 import { UserStateContext } from "../contexts/user";
 import LoadingPage from "./LoadingPage";
 import { Link } from "react-router-dom";
+import { signIn } from "../auth";
 
 const TopPage: React.FC = () => {
   const us = useContext(UserStateContext);
@@ -27,11 +28,11 @@ const TopPage: React.FC = () => {
       <Divider />
       {us.state === "loading" ? (
         <LoadingPage />
-      ) : us.state === "signed out" ? (
+      ) : us.state === "signedOut" ? (
         <>
           <Typography sx={{ mt: 6, mb: 1 }}>始めるには</Typography>
           <Button
-            onClick={us.signIn}
+            onClick={signIn}
             variant="contained"
             sx={{ textTransform: "none" }}
           >


### PR DESCRIPTION
- ログイン周りのコードを auth.ts にまとめた
- screenName の設定を実際にログインされたときのみするように
- screenName と screenNameLowerCase を別々に保存するように
  - これ以降ログインしてないユーザのページが一時的に見れなくなるが、再ログインで治る
- Fab を position fixed に修正 